### PR TITLE
Show only mrrl items, add option to show components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ interface State {
   route: RouteStep[];
   requiredMats: Materials;
   includeSecretShop: boolean;
+  showComponents: boolean;
   includeVendorPictures: boolean;
   selectedItems: { [itemId: number]: any };
 }
@@ -29,6 +30,7 @@ const App: React.FC = () => {
     route: [],
     requiredMats: { items: [], gold: 0 },
     includeSecretShop: true,
+    showComponents: false,
     includeVendorPictures: true,
     selectedItems: {}
   });
@@ -106,6 +108,15 @@ const App: React.FC = () => {
     }));
   };
 
+  const onShowComponentsChangeChecked = (event: ChangeEvent<HTMLInputElement>) => {
+    const checked = event.target.checked;
+
+    setState(prevState => ({
+      ...prevState,
+      showComponents: checked
+    }));
+  };
+
   const onIncludeVendorPicturesChange = (
     event: ChangeEvent<HTMLInputElement>
   ) => {
@@ -141,6 +152,7 @@ const App: React.FC = () => {
         onQuantityChange={onQuantityChange}
         wantedItems={state.wantedItems}
         includeSecretShop={state.includeSecretShop}
+        showComponents={state.showComponents}
       />
       <label>
         <input
@@ -149,6 +161,15 @@ const App: React.FC = () => {
           onChange={onSecretShopChangeChecked}
         />
         Include secret shop (cloak required)
+      </label>
+      <br />
+      <label>
+        <input
+          type="checkbox"
+          checked={state.showComponents}
+          onChange={onShowComponentsChangeChecked}
+        />
+        Show components
       </label>
       <br />
       <label>

--- a/src/components/WantedItems.tsx
+++ b/src/components/WantedItems.tsx
@@ -8,13 +8,15 @@ let offeredItems = getMaterialsInput();
 interface Props {
   wantedItems: WantedItem[];
   includeSecretShop: boolean;
+  showComponents: boolean;
   onQuantityChange: (itemId: number, quantity: number) => void;
 }
 
 const WantedItems: React.FC<Props> = ({
   onQuantityChange,
   wantedItems,
-  includeSecretShop
+  includeSecretShop,
+  showComponents
 }) => {
   const onWantChange = (event: ChangeEvent<HTMLInputElement>) => {
     const target = event.target;
@@ -41,7 +43,7 @@ const WantedItems: React.FC<Props> = ({
       <h2>Materials</h2>
       <div>
         {offeredItems
-          .filter(item => !item.secret || includeSecretShop)
+          .filter(item => (item.mrrl || showComponents) && (!item.secret || includeSecretShop))
           .map(item => (
             <div key={item.itemId} className={`col-6 ${style.item}`}>
               <input

--- a/src/data/functions.ts
+++ b/src/data/functions.ts
@@ -36,9 +36,6 @@ export function getItem(itemId: number): Item {
 
 export function getMaterialsInput(): Item[] {
   return items
-    .filter(
-      i => !i.mrrl && (i.rarity === Rarity.Rare || i.rarity === Rarity.Epic)
-    )
     .sort((a, b) => {
       if (a.rarity === b.rarity) {
         return a.name.localeCompare(b.name);


### PR DESCRIPTION
I found it odd that I had to add up all the components of the things I actually wanted to buy. This change makes the items from Mrrl the focus of the page. I also added an option to show the component items to be able to retain the previous behaviour.